### PR TITLE
Lock down dependencies to be more conservative about upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   },
   "homepage": "http://github.com/andris9/nodemailer-smtp-pool",
   "dependencies": {
-    "clone": "^1.0.2",
-    "nodemailer-wellknown": "^0.1.7",
-    "smtp-connection": "^1.3.7"
+    "clone": "1.3.1",
+    "nodemailer-wellknown": "0.1.7",
+    "smtp-connection": "1.3.7"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
This is to prevent surprise changes in behavior such as https://github.com/andris9/smtp-connection/issues/32

I completely understand the intent here to use the caret, but please hear where I'm coming from. I send millions of emails through this wonderful framework and I absolutely cannot have surprise changes in behavior. It'd be extremely helpful if we can lock down the dependencies so I can qualify each upgrade.